### PR TITLE
Have the Grunt task error when the Gulp task returns a rejected promise

### DIFF
--- a/tasks/gulp.js
+++ b/tasks/gulp.js
@@ -18,7 +18,10 @@ module.exports = function(grunt) {
 
     if (typeof this.data === 'function') {
       gulp.task('default', this.data);
-      gulp.start('default', done);
+      gulp.start('default', function(err) {
+        if(err) done(false);  // `false` to error out the grunt task
+        else done();
+      } );
     } else {
       gulp.task('default', function() {
         var count = grunttask.files.length;


### PR DESCRIPTION
This is a fix to have the Grunt task error out when returning a rejected Promise from the Gulp task.

Here is the configuration that this now supports:

```js
gulp : {
  test_promise: function() {
    return Promise.reject('my-error');
  }
}
```

And the result on the console: 

![image](https://cloud.githubusercontent.com/assets/302273/20074026/95604dce-a4fc-11e6-9ab8-83739f42ac01.png)

Fixes #11 